### PR TITLE
Remove deprecated 'relative permalinks'

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -24,4 +24,4 @@ highlighter: pygments
 
 # Permalinks
 permalink: pretty
-relative_permalinks: true
+


### PR DESCRIPTION
Page build fails - no longer supported
